### PR TITLE
fix: wrong cae parameter name for azure identity

### DIFF
--- a/kiota_authentication_azure/azure_identity_access_token_provider.py
+++ b/kiota_authentication_azure/azure_identity_access_token_provider.py
@@ -103,12 +103,12 @@ class AzureIdentityAccessTokenProvider(AccessTokenProvider):
                 result = self._credentials.get_token(
                     *self._scopes,
                     claims=decoded_claim,
-                    is_cae_enabled=self._is_cae_enabled,
+                    enable_cae=self._is_cae_enabled,
                     **self._options
                 )
             else:
                 result = self._credentials.get_token(
-                    *self._scopes, claims=decoded_claim, is_cae_enabled=self._is_cae_enabled
+                    *self._scopes, claims=decoded_claim, enable_cae=self._is_cae_enabled
                 )
 
             if inspect.isawaitable(result):

--- a/tests/test_azure_identity_authentication_provider.py
+++ b/tests/test_azure_identity_authentication_provider.py
@@ -42,5 +42,5 @@ async def test_adds_claim_to_the_token_context(mocker):
     credential.get_token.assert_called_once_with(
         'https://graph.microsoft.com/.default',
         claims="""{"access_token":{"nbf":{"essential":true, "value":"1652813508"}}}""",
-        is_cae_enabled=True
+        enable_cae=True
     )


### PR DESCRIPTION
follow up to #415
No need for a version bump because the issue was caught before release
https://github.com/Azure/azure-sdk-for-python/blob/513989e008612fa053dfa8ec1318a6c4bcdbf991/sdk/core/azure-core/azure/core/credentials_async.py#L21C9-L21C19